### PR TITLE
Fluentd json formatter (built-in) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Serilog log JSON tends to look like this:
 }
 
 ```
+
 The LogstashJsonFormatter flattens that structure so it is more likely to fit into an existing logstash infrastructure.
 
 ```
@@ -103,6 +104,58 @@ The LogstashJsonFormatter flattens that structure so it is more likely to fit in
   "environment": "production",
 }
 
+```
+
+# Usage with Fluentd input_forwarder plugin (json mode)
+
+Set up to log to Fluentd via TCP
+
+```csharp
+
+var urlLogger = new LoggerConfiguration()
+    .WriteTo.FluentdTCPSink("127.0.0.1", 24224, "applogs")
+    .CreateLogger();
+
+```
+Set up to log to Fluentd via UDP
+
+```csharp
+
+var urlLogger = new LoggerConfiguration()
+    .WriteTo.FluentdUDPSink("127.0.0.1", 24224, "applogs")
+    .CreateLogger();
+
+```
+
+Sample of fluentd.conf
+```
+<source>
+  @type forward
+  port 24224
+</source>
+
+<match applogs>
+  @type copy
+  <store>
+    @type stdout
+  </store>
+  <store>
+    @type elasticsearch
+    host elastic
+    port 9200
+    logstash_format true
+    logstash_prefix serilog
+    buffer_type memory
+    flush_interval 10s
+    retry_limit 17
+    retry_wait 1.0
+    reload_connections false
+    reconnect_on_error true
+    reload_on_failure true
+    request_timeout 300s
+    num_threads 2
+  </store>
+</match>
 ```
 
 # Acknowledgements

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The LogstashJsonFormatter flattens that structure so it is more likely to fit in
 
 ```
 
-# Usage with Fluentd input_forwarder plugin (json mode)
+# Usage with Fluentd  [in_forward](https://docs.fluentd.org/input/forward) plugin (json mode)
 
 Set up to log to Fluentd via TCP
 
@@ -117,6 +117,7 @@ var urlLogger = new LoggerConfiguration()
     .CreateLogger();
 
 ```
+
 Set up to log to Fluentd via UDP
 
 ```csharp
@@ -128,6 +129,7 @@ var urlLogger = new LoggerConfiguration()
 ```
 
 Sample of fluentd.conf
+
 ```
 <source>
   @type forward

--- a/Serilog.Sinks.Network/Formatters/FluentdJsonFormatter.cs
+++ b/Serilog.Sinks.Network/Formatters/FluentdJsonFormatter.cs
@@ -41,7 +41,7 @@ namespace Serilog.Sinks.Network.Formatters
                     _defaultTag = sourceContext.ToString();
                 }
 
-                output.Write($"[{_defaultTag}, {DateTimeOffset.Now.ToEpochTime()}, {logEventWriter}]");
+                output.Write($"[{_defaultTag}, {DateTimeOffset.Now.ToUnixTimeSeconds()}, {logEventWriter}]");
             }
         }
     }

--- a/Serilog.Sinks.Network/Formatters/FluentdJsonFormatter.cs
+++ b/Serilog.Sinks.Network/Formatters/FluentdJsonFormatter.cs
@@ -41,7 +41,7 @@ namespace Serilog.Sinks.Network.Formatters
                     _defaultTag = sourceContext.ToString();
                 }
 
-                output.Write($"[{_defaultTag}, {DateTimeOffset.Now.ToUnixTimeSeconds()}, {logEventWriter}]");
+                output.Write($"[{_defaultTag}, {logEvent.Timestamp.ToUnixTimeSeconds()}, {logEventWriter}]");
             }
         }
     }

--- a/Serilog.Sinks.Network/Formatters/FluentdJsonFormatter.cs
+++ b/Serilog.Sinks.Network/Formatters/FluentdJsonFormatter.cs
@@ -1,0 +1,48 @@
+// Adapted from RawJsonFormatter in Serilog.Sinks.Seq Copyright 2016 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.IO;
+using Serilog.Events;
+using Serilog.Formatting;
+using Serilog.Formatting.Json;
+
+namespace Serilog.Sinks.Network.Formatters
+{
+    public class FluentdJsonFormatter : ITextFormatter
+    {
+        private readonly JsonFormatter jsonFormatter;
+        private string _defaultTag;
+
+        public FluentdJsonFormatter(string defaultTag)
+        {
+            jsonFormatter = new JsonFormatter();
+            _defaultTag = "\"" + defaultTag + "\"";
+        }
+
+        public void Format(LogEvent logEvent, TextWriter output)
+        {
+            using (TextWriter logEventWriter = new StringWriter())
+            {
+                jsonFormatter.Format(logEvent, logEventWriter);
+                if (logEvent.Properties.TryGetValue("SourceContext", out var sourceContext))
+                {
+                    _defaultTag = sourceContext.ToString();
+                }
+
+                output.Write($"[{_defaultTag}, {DateTimeOffset.Now.ToEpochTime()}, {logEventWriter}]");
+            }
+        }
+    }
+}

--- a/Serilog.Sinks.Network/NetworkLoggerConfigurationExtensions.cs
+++ b/Serilog.Sinks.Network/NetworkLoggerConfigurationExtensions.cs
@@ -78,18 +78,6 @@ namespace Serilog.Sinks.Network
             return loggerSinkConfiguration.UDPSink($"udp://{ip}", port, new FluentdJsonFormatter(defaultTag));
         }
 
-        public static long ToEpochTime(this DateTimeOffset offset)
-        {
-            var utcDate = offset.ToUniversalTime();
-            long baseTicks = 621355968000000000;
-            long tickResolution = 10000000;
-            long epoch = (utcDate.Ticks - baseTicks) / tickResolution;
-            long epochTicks = (epoch * tickResolution) + baseTicks;
-            var date = new DateTime(epochTicks, DateTimeKind.Utc);
-
-            return epoch;
-        }
-
         private static IPAddress ResolveAddress(string uri)
         {
             // Check if it is IP address

--- a/Serilog.Sinks.Network/NetworkLoggerConfigurationExtensions.cs
+++ b/Serilog.Sinks.Network/NetworkLoggerConfigurationExtensions.cs
@@ -68,6 +68,28 @@ namespace Serilog.Sinks.Network
             return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);
         }
 
+        public static LoggerConfiguration FluentdTCPSink(this LoggerSinkConfiguration loggerSinkConfiguration, string ip, int port, string defaultTag)
+        {
+            return loggerSinkConfiguration.TCPSink($"tcp://{ip}", port, new FluentdJsonFormatter(defaultTag));
+        }
+
+        public static LoggerConfiguration FluentdUDPSink(this LoggerSinkConfiguration loggerSinkConfiguration, string ip, int port, string defaultTag)
+        {
+            return loggerSinkConfiguration.UDPSink($"udp://{ip}", port, new FluentdJsonFormatter(defaultTag));
+        }
+
+        public static long ToEpochTime(this DateTimeOffset offset)
+        {
+            var utcDate = offset.ToUniversalTime();
+            long baseTicks = 621355968000000000;
+            long tickResolution = 10000000;
+            long epoch = (utcDate.Ticks - baseTicks) / tickResolution;
+            long epochTicks = (epoch * tickResolution) + baseTicks;
+            var date = new DateTime(epochTicks, DateTimeKind.Utc);
+
+            return epoch;
+        }
+
         private static IPAddress ResolveAddress(string uri)
         {
             // Check if it is IP address


### PR DESCRIPTION
Hey,
As you may know there is Serilog.Fluentd formatter in Serilog-Contrib sinks. But it is **unstable**, **queue-less**, does not support reconnection policies and is only bound to Fluentd. 

There is another solution to be implemented through TCP or UDP connections here. I just wrote a simple json formatter to serialize logs and send them through TCP or UDP to Fluentd.