### PR TITLE
Lower TargetFramework to net6.0

### DIFF
--- a/Serilog.Sinks.Network.Test/LoggerAndSocket.cs
+++ b/Serilog.Sinks.Network.Test/LoggerAndSocket.cs
@@ -1,5 +1,21 @@
 using System.Net.Sockets;
 
+namespace System.Runtime.CompilerServices
+{
+    public class RequiredMemberAttribute : Attribute { }
+    public class CompilerFeatureRequiredAttribute : Attribute
+    {
+        public CompilerFeatureRequiredAttribute(string name) { }
+    }
+}
+namespace System.Diagnostics.CodeAnalysis
+{
+    [System.AttributeUsage(System.AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+    public sealed class SetsRequiredMembersAttribute : Attribute
+    {
+    }
+}
+
 namespace Serilog.Sinks.Network.Test
 {
     public record LoggerAndSocket : System.IDisposable

--- a/Serilog.Sinks.Network.Test/Serilog.Sinks.Network.Test.csproj
+++ b/Serilog.Sinks.Network.Test/Serilog.Sinks.Network.Test.csproj
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>Preview</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />

--- a/Serilog.Sinks.Network/Serilog.Sinks.Network.csproj
+++ b/Serilog.Sinks.Network/Serilog.Sinks.Network.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Serilog.Sinks.Network</RootNamespace>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
Turns out we have some projects that are still on `net6.0`, so we would like to target that instead.
I'm aware there is no longer LTS for net6.0.