### PR TITLE
Enable <Nullable> in tests project and address warnings

### DIFF
--- a/Serilog.Sinks.Network.Test/JsonFormatter.cs
+++ b/Serilog.Sinks.Network.Test/JsonFormatter.cs
@@ -11,7 +11,7 @@ namespace Serilog.Sinks.Network.Test
 {
     public class JsonFormatter
     {
-        private static LoggerAndSocket ConfigureTestLogger(ITextFormatter formatter = null)
+        private static LoggerAndSocket ConfigureTestLogger(ITextFormatter? formatter = null)
         {
             var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));

--- a/Serilog.Sinks.Network.Test/Serilog.Sinks.Network.Test.csproj
+++ b/Serilog.Sinks.Network.Test/Serilog.Sinks.Network.Test.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>Preview</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />

--- a/Serilog.Sinks.Network.Test/WhenLoggingViaTcp.cs
+++ b/Serilog.Sinks.Network.Test/WhenLoggingViaTcp.cs
@@ -15,7 +15,7 @@ namespace Serilog.Sinks.Network.Test
 {
     public class WhenLoggingViaTcp
     {
-        private static LoggerAndSocket ConfigureTestLogger(ITextFormatter formatter = null)
+        private static LoggerAndSocket ConfigureTestLogger(ITextFormatter? formatter = null)
         {
             var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
             socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
@@ -66,7 +66,7 @@ namespace Serilog.Sinks.Network.Test
             using var fixture = ConfigureTestLogger();
             fixture.Logger.Information("TCP Hello {location}", "world");
             var receivedData = await ServerPoller.PollForReceivedData(fixture.Socket);
-            dynamic payload = JsonConvert.DeserializeObject<ExpandoObject>(receivedData);
+            dynamic? payload = JsonConvert.DeserializeObject<ExpandoObject>(receivedData);
             if (payload == null)
             {
                 throw new AssertionFailedException("expected payload not null");

--- a/Serilog.Sinks.Network.Test/WhenLoggingViaUdp.cs
+++ b/Serilog.Sinks.Network.Test/WhenLoggingViaUdp.cs
@@ -15,7 +15,7 @@ namespace Serilog.Sinks.Network.Test
 {
     public class WhenLoggingViaUdp 
     {
-        private static LoggerAndSocket ConfigureTestLogger(ITextFormatter formatter = null)
+        private static LoggerAndSocket ConfigureTestLogger(ITextFormatter? formatter = null)
         {
             var socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
             socket.Bind(new IPEndPoint(IPAddress.Loopback, 0));


### PR DESCRIPTION
While working on https://github.com/serilog-contrib/Serilog.Sinks.Network/pull/55 I noticed that `<Nullable>` was not enabled in the tests project while it was already enabled in the main project. I thought it would be helpful to have `<Nullable>` enabled in the tests project as well.