### PR TITLE
Enable <Nullable> in PingPonger.csproj and address warnings

### DIFF
--- a/PingPonger/PingPonger.csproj
+++ b/PingPonger/PingPonger.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Serilog.Sinks.ColoredConsole" Version="3.0.1"/>

--- a/PingPonger/Program.cs
+++ b/PingPonger/Program.cs
@@ -21,11 +21,11 @@ namespace PingPonger
 
         [Option('i', "ip", Required = false,
                 HelpText = "IP to send to")]
-        public string IP { get; set; }
+        public string? IP { get; set; }
 
         [Option('l', "url", Required = false,
         HelpText = "URL to send to")]
-        public string Url { get; set; }
+        public string? Url { get; set; }
 
         [Option('p', "port", Required = false,
                 HelpText = "the Port to send to")]
@@ -60,7 +60,7 @@ namespace PingPonger
 
                 logConfig.WriteTo.ColoredConsole();
 
-                if (options.Url.Length > 0)
+                if (options.Url?.Length > 0)
                 {
                     if (options.UDP)
                     {
@@ -71,10 +71,9 @@ namespace PingPonger
                         logConfig.WriteTo.TCPSink(options.Url, options.Port, null, null, new LogstashJsonFormatter());
                     }
                 }
-                else if (options.IP.Length > 0)
+                else if (options.IP?.Length > 0)
                 {
-                    IPAddress ipAddress;
-                    if (!IPAddress.TryParse(options.IP, out ipAddress))
+                    if (!IPAddress.TryParse(options.IP, out var ipAddress))
                     {
                         Console.WriteLine("Could not parse " + options.IP + " as an IP address");
                         return 1;

--- a/Serilog.Sinks.Network/Sinks/TCP/TCPSocketWriter.cs
+++ b/Serilog.Sinks.Network/Sinks/TCP/TCPSocketWriter.cs
@@ -206,7 +206,7 @@ namespace Serilog.Sinks.Network.Sinks.TCP
             }
         }
 
-        private async Task FlushQueue(string entry)
+        private async Task FlushQueue(string? entry)
         {
             while (_eventQueue.Count > 0)
             {
@@ -285,7 +285,7 @@ namespace Serilog.Sinks.Network.Sinks.TCP
     {
         private const int Ceiling = 10 * 60; // 10 minutes in seconds
 
-        public static async Task<Stream> ConnectAsync(Func<Uri, Task<Stream>> connect, Uri host,
+        public static async Task<Stream?> ConnectAsync(Func<Uri, Task<Stream>> connect, Uri host,
             CancellationToken cancellationToken)
         {
             int delay = 1; // in seconds


### PR DESCRIPTION
I noticed this was not enabled while working on https://github.com/serilog-contrib/Serilog.Sinks.Network/pull/55 and thought it would be helpful to have it enabled.

Separate PR here https://github.com/serilog-contrib/Serilog.Sinks.Network/pull/56 for the tests project. 