### PR TITLE
Adjust overloads and parameter order to resolve potential ambiguous method call errors

### DIFF
--- a/Serilog.Sinks.Network.Test/JsonFormatter.cs
+++ b/Serilog.Sinks.Network.Test/JsonFormatter.cs
@@ -17,7 +17,7 @@ namespace Serilog.Sinks.Network.Test
     {
         private static LoggerAndSocket ConfigureTestLogger(
             ITextFormatter? formatter = null,
-            ILogEventEnricher[] enrichers = null
+            ILogEventEnricher[]? enrichers = null
         )
         {
             var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
@@ -79,7 +79,7 @@ namespace Serilog.Sinks.Network.Test
 
             var receivedData = await ServerPoller.PollForReceivedData(fixture.Socket);
 
-            receivedData.Should().Contain($"\"traceId\":\"{activity.TraceId}\"");
+            receivedData.Should().Contain($"\"traceId\":\"{activity!.TraceId}\"");
             receivedData.Should().Contain($"\"spanId\":\"{activity.SpanId}\"");
         }
 
@@ -119,7 +119,7 @@ namespace Serilog.Sinks.Network.Test
 
             var receivedData = await ServerPoller.PollForReceivedData(fixture.Socket);
 
-            var indexOfTraceId = receivedData.IndexOf($"\"traceId\":\"{activity.TraceId}\"");
+            var indexOfTraceId = receivedData.IndexOf($"\"traceId\":\"{activity!.TraceId}\"");
             var indexOfTraceIdFromEnricher = receivedData.IndexOf("\"traceId\":\"traceId-from-enricher\"");
             indexOfTraceId.Should().BePositive().And.BeLessThan(indexOfTraceIdFromEnricher);
 

--- a/Serilog.Sinks.Network.Test/JsonFormatter.cs
+++ b/Serilog.Sinks.Network.Test/JsonFormatter.cs
@@ -25,7 +25,7 @@ namespace Serilog.Sinks.Network.Test
             socket.Listen();
 
             var loggerConfiguration = new LoggerConfiguration()
-                .WriteTo.TCPSink(IPAddress.Loopback, ((IPEndPoint)socket.LocalEndPoint!).Port, null, null, formatter);
+                .WriteTo.TCPSink(IPAddress.Loopback, ((IPEndPoint)socket.LocalEndPoint!).Port, formatter);
             if (enrichers != null)
             {
                 loggerConfiguration.Enrich.With(enrichers);

--- a/Serilog.Sinks.Network.Test/WhenLoggingViaTcp.cs
+++ b/Serilog.Sinks.Network.Test/WhenLoggingViaTcp.cs
@@ -22,7 +22,7 @@ namespace Serilog.Sinks.Network.Test
             socket.Listen();
 
             var logger = new LoggerConfiguration()
-                .WriteTo.TCPSink(IPAddress.Loopback, ((IPEndPoint)socket.LocalEndPoint!).Port, null, null, formatter)
+                .WriteTo.TCPSink(IPAddress.Loopback, ((IPEndPoint)socket.LocalEndPoint!).Port, formatter)
                 .CreateLogger();
 
             return new LoggerAndSocket { Logger = logger, Socket = socket };

--- a/Serilog.Sinks.Network/NetworkLoggerConfigurationExtensions.cs
+++ b/Serilog.Sinks.Network/NetworkLoggerConfigurationExtensions.cs
@@ -41,42 +41,33 @@ namespace Serilog.Sinks.Network
             this LoggerSinkConfiguration loggerConfiguration,
             IPAddress ipAddress,
             int port,
-            int? writeTimeoutMs = null,
-            int? disposeTimeoutMs = null,
             ITextFormatter? textFormatter = null,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            int? writeTimeoutMs = null,
+            int? disposeTimeoutMs = null)
         {
-            return TCPSink(loggerConfiguration, $"tcp://{ipAddress}:{port}", writeTimeoutMs, disposeTimeoutMs,  textFormatter, restrictedToMinimumLevel);
-        }
-
-        public static LoggerConfiguration TCPSink(
-            this LoggerSinkConfiguration loggerConfiguration,
-            IPAddress ipAddress,
-            int port,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
-        {
-            return TCPSink(loggerConfiguration, ipAddress, port,null, null, null, restrictedToMinimumLevel);
+            return TCPSink(loggerConfiguration, $"tcp://{ipAddress}:{port}", textFormatter, restrictedToMinimumLevel, writeTimeoutMs, disposeTimeoutMs);
         }
 
         public static LoggerConfiguration TCPSink(
             this LoggerSinkConfiguration loggerConfiguration,
             string host,
             int port,
-            int? writeTimeoutMs = null,
-            int? disposeTimeoutMs = null,
             ITextFormatter? textFormatter = null,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            int? writeTimeoutMs = null,
+            int? disposeTimeoutMs = null)
         {
-            return TCPSink(loggerConfiguration, $"{host}:{port}", writeTimeoutMs, disposeTimeoutMs, textFormatter, restrictedToMinimumLevel);
+            return TCPSink(loggerConfiguration, $"{host}:{port}", textFormatter, restrictedToMinimumLevel, writeTimeoutMs, disposeTimeoutMs);
         }
 
         public static LoggerConfiguration TCPSink(
             this LoggerSinkConfiguration loggerConfiguration,
             string uri,
-            int? writeTimeoutMs = null,
-            int? disposeTimeoutMs = null,
             ITextFormatter? textFormatter = null,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            int? writeTimeoutMs = null,
+            int? disposeTimeoutMs = null)
         {
             var socketWriter = new TcpSocketWriter(
                 BuildUri(uri),
@@ -86,14 +77,6 @@ namespace Serilog.Sinks.Network
             return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);
         }
         
-        public static LoggerConfiguration TCPSink(
-            this LoggerSinkConfiguration loggerConfiguration,
-            string uri,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
-        {
-            return TCPSink(loggerConfiguration, uri, null, null, null, restrictedToMinimumLevel);
-        }
-
         private static IPAddress ResolveAddress(string uri)
         {
             // Check if it is IP address


### PR DESCRIPTION
fixes #58 

- Remove new overloads that can cause ambiguity. See comments on this PR for details.
- Move new optional parameters `int? writeTimeoutMs = null, int? disposeTimeoutMs = null` added in #51 to the end of the parameter lists of pre-existing methods to maintain signature compatibility with 2.x version of this library.
- Fix the PingPonger app command line arg handling and add a call to `TCPSink(string uri)` to verify it is no longer an ambiguous method call.